### PR TITLE
feat(ambient): add ambient mode support for BetterPlayer

### DIFF
--- a/lib/better_player.dart
+++ b/lib/better_player.dart
@@ -26,6 +26,7 @@ export 'src/controls/better_player_multiple_gesture_detector.dart';
 export 'src/controls/better_player_overflow_menu_item.dart';
 export 'src/controls/better_player_progress_colors.dart';
 export 'src/core/better_player.dart';
+export 'src/core/better_player_ambient.dart';
 export 'src/core/better_player_controller.dart';
 export 'src/core/better_player_controller_provider.dart';
 export 'src/list/better_player_list_video_player.dart';

--- a/lib/src/configuration/better_player_configuration.dart
+++ b/lib/src/configuration/better_player_configuration.dart
@@ -133,6 +133,24 @@ class BetterPlayerConfiguration {
   ///Widget to display on the left side of the top bar
   final Widget? widgetInTopBarLeft;
 
+  ///Enable replicated blurred background behind the video similar to YouTube Ambient Mode.
+  final bool enableAmbientMode;
+
+  ///Show ambient only when the player is fullscreen.
+  final bool ambientModeFullScreenOnly;
+
+  ///Restrict ambient effect to landscape orientation (recommended for horizontal fullscreen).
+  final bool ambientModeLandscapeOnly;
+
+  ///Blur sigma applied to the replicated video surface.
+  final double ambientBlurSigma;
+
+  ///Scale factor for the replicated video surface relative to original.
+  final double ambientScale;
+
+  ///Darken overlay (0-1) placed above the blurred video to reduce glare.
+  final double ambientDarken;
+
   const BetterPlayerConfiguration({
     this.aspectRatio,
     this.autoPlay = false,
@@ -175,6 +193,12 @@ class BetterPlayerConfiguration {
     this.mixWithOthers = false,
     this.widgetBelowSeekBar,
     this.widgetInTopBarLeft,
+    this.enableAmbientMode = true,
+    this.ambientModeFullScreenOnly = true,
+    this.ambientModeLandscapeOnly = true,
+    this.ambientBlurSigma = 60,
+    this.ambientScale = 1.25,
+    this.ambientDarken = 0.55,
   });
 
   BetterPlayerConfiguration copyWith({
@@ -212,6 +236,12 @@ class BetterPlayerConfiguration {
     bool? mixWithOthers,
     Widget? widgetBelowSeekBar,
     Widget? widgetInTopBarLeft,
+    bool? enableAmbientMode,
+    bool? ambientModeFullScreenOnly,
+    bool? ambientModeLandscapeOnly,
+    double? ambientBlurSigma,
+    double? ambientScale,
+    double? ambientDarken,
   }) {
     return BetterPlayerConfiguration(
       aspectRatio: aspectRatio ?? this.aspectRatio,
@@ -258,6 +288,14 @@ class BetterPlayerConfiguration {
       mixWithOthers: mixWithOthers ?? this.mixWithOthers,
       widgetBelowSeekBar: widgetBelowSeekBar ?? this.widgetBelowSeekBar,
       widgetInTopBarLeft: widgetInTopBarLeft ?? this.widgetInTopBarLeft,
+      enableAmbientMode: enableAmbientMode ?? this.enableAmbientMode,
+      ambientModeFullScreenOnly:
+          ambientModeFullScreenOnly ?? this.ambientModeFullScreenOnly,
+      ambientModeLandscapeOnly:
+          ambientModeLandscapeOnly ?? this.ambientModeLandscapeOnly,
+      ambientBlurSigma: ambientBlurSigma ?? this.ambientBlurSigma,
+      ambientScale: ambientScale ?? this.ambientScale,
+      ambientDarken: ambientDarken ?? this.ambientDarken,
     );
   }
 }

--- a/lib/src/core/better_player.dart
+++ b/lib/src/core/better_player.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'package:better_player/better_player.dart';
 import 'package:better_player/src/configuration/better_player_controller_event.dart';
+import 'package:better_player/src/core/better_player_ambient.dart';
 import 'package:better_player/src/core/better_player_utils.dart';
 import 'package:better_player/src/core/better_player_with_controls.dart';
 import 'package:flutter/material.dart';
@@ -394,10 +395,12 @@ class _BetterPlayerState extends State<BetterPlayer>
       BetterPlayerControllerProvider controllerProvider) {
     return Scaffold(
       resizeToAvoidBottomInset: false,
-      body: Container(
-        alignment: Alignment.center,
-        color: Colors.black,
-        child: controllerProvider,
+      body: BetterPlayerAmbientBackdrop(
+        controller: widget.controller,
+        child: Container(
+          alignment: Alignment.center,
+          child: controllerProvider,
+        ),
       ),
     );
   }

--- a/lib/src/core/better_player_ambient.dart
+++ b/lib/src/core/better_player_ambient.dart
@@ -1,0 +1,130 @@
+import 'dart:ui';
+
+import 'package:better_player/better_player.dart';
+import 'package:better_player/src/video_player/video_player.dart';
+import 'package:flutter/material.dart';
+
+///Wraps the player with a blurred replica of the current video to emulate Ambient Mode.
+class BetterPlayerAmbientBackdrop extends StatelessWidget {
+  const BetterPlayerAmbientBackdrop({
+    required this.controller,
+    required this.child,
+    super.key,
+  });
+
+  final BetterPlayerController controller;
+  final Widget child;
+
+  bool _shouldShowAmbient(BuildContext context) {
+    final configuration = controller.betterPlayerConfiguration;
+
+    if (!configuration.enableAmbientMode) {
+      return false;
+    }
+
+    if (configuration.ambientModeFullScreenOnly && !controller.isFullScreen) {
+      return false;
+    }
+
+    if (configuration.ambientModeLandscapeOnly) {
+      final orientation = MediaQuery.maybeOf(context)?.orientation;
+      if (orientation == null || orientation != Orientation.landscape) {
+        return false;
+      }
+    }
+
+    final videoController = controller.videoPlayerController;
+    if (videoController == null || !videoController.value.initialized) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final fallbackColor = controller
+        .betterPlayerConfiguration.controlsConfiguration.backgroundColor;
+
+    if (!_shouldShowAmbient(context)) {
+      return DecoratedBox(
+        decoration: BoxDecoration(color: fallbackColor),
+        child: child,
+      );
+    }
+
+    final configuration = controller.betterPlayerConfiguration;
+    final blurSigma = configuration.ambientBlurSigma.clamp(0, 100).toDouble();
+    final scale = configuration.ambientScale.clamp(1.0, 2.0);
+    final darken = configuration.ambientDarken.clamp(0.0, 1.0);
+
+    return Stack(
+      fit: StackFit.passthrough,
+      children: [
+        Positioned.fill(
+          child: IgnorePointer(
+            child: AnimatedOpacity(
+              opacity:
+                  controller.videoPlayerController?.value.initialized == true
+                      ? 1
+                      : 0,
+              duration: const Duration(milliseconds: 300),
+              child: ClipRect(
+                child: Stack(
+                  fit: StackFit.expand,
+                  children: [
+                    Transform.scale(
+                      scale: scale,
+                      child: ImageFiltered(
+                        imageFilter: ImageFilter.blur(
+                          sigmaX: blurSigma,
+                          sigmaY: blurSigma,
+                        ),
+                        child: _AmbientVideoSurface(
+                          controller: controller,
+                        ),
+                      ),
+                    ),
+                    Container(
+                      color: Colors.black.withValues(alpha: darken),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+        child,
+      ],
+    );
+  }
+}
+
+class _AmbientVideoSurface extends StatelessWidget {
+  const _AmbientVideoSurface({
+    required this.controller,
+  });
+
+  final BetterPlayerController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    final videoController = controller.videoPlayerController;
+    if (videoController == null ||
+        !videoController.value.initialized ||
+        videoController.value.size == null ||
+        videoController.value.size == Size.zero) {
+      return const SizedBox();
+    }
+
+    final size = videoController.value.size!;
+    return FittedBox(
+      fit: BoxFit.cover,
+      child: SizedBox(
+        width: size.width,
+        height: size.height,
+        child: VideoPlayer(videoController),
+      ),
+    );
+  }
+}

--- a/lib/src/core/better_player_with_controls.dart
+++ b/lib/src/core/better_player_with_controls.dart
@@ -28,7 +28,7 @@ class _BetterPlayerWithControlsState extends State<BetterPlayerWithControls> {
       widget.controller!.betterPlayerControlsConfiguration;
 
   final StreamController<bool> playerVisibilityStreamController =
-      StreamController();
+      StreamController.broadcast();
 
   bool _initialized = false;
 
@@ -93,10 +93,15 @@ class _BetterPlayerWithControlsState extends State<BetterPlayerWithControls> {
     }
 
     aspectRatio ??= 16 / 9;
+    final bool isAmbientCandidate =
+        _shouldUseAmbientBackground(betterPlayerController, context);
+
     final innerContainer = Container(
       width: double.infinity,
-      color: betterPlayerController
-          .betterPlayerConfiguration.controlsConfiguration.backgroundColor,
+      color: isAmbientCandidate
+          ? Colors.transparent
+          : betterPlayerController
+              .betterPlayerConfiguration.controlsConfiguration.backgroundColor,
       child: AspectRatio(
         aspectRatio: aspectRatio,
         child: _buildPlayerWithControls(betterPlayerController, context),
@@ -152,6 +157,24 @@ class _BetterPlayerWithControlsState extends State<BetterPlayerWithControls> {
         ],
       ),
     );
+  }
+
+  bool _shouldUseAmbientBackground(
+      BetterPlayerController controller, BuildContext context) {
+    final configuration = controller.betterPlayerConfiguration;
+    if (!configuration.enableAmbientMode) {
+      return false;
+    }
+    if (configuration.ambientModeFullScreenOnly && !controller.isFullScreen) {
+      return false;
+    }
+    if (configuration.ambientModeLandscapeOnly) {
+      final orientation = MediaQuery.maybeOf(context)?.orientation;
+      if (orientation == null || orientation != Orientation.landscape) {
+        return false;
+      }
+    }
+    return true;
   }
 
   Widget _buildPlaceholder(BetterPlayerController betterPlayerController) {


### PR DESCRIPTION
- Introduced `BetterPlayerAmbientBackdrop` to create a blurred background effect during video playback, emulating YouTube's Ambient Mode.
- Enhanced `BetterPlayerConfiguration` with new properties to control ambient mode behavior, including fullscreen and landscape restrictions.
- Updated `BetterPlayerWithControls` to conditionally apply a transparent background when ambient mode is active.
- Refactored `BetterPlayer` to integrate the ambient backdrop into the player UI.